### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -14,7 +14,7 @@ class action_plugin_indexnumber extends DokuWiki_Action_Plugin {
   /*
    * Register the handlers with the dokuwiki's event controller
    */
-  function register(&$controller) {
+  function register(Doku_Event_Handler $controller) {
     $controller->register_hook('TOOLBAR_DEFINE', 'AFTER',  $this, 'add_button');
   }
  

--- a/syntax.php
+++ b/syntax.php
@@ -73,7 +73,7 @@ class syntax_plugin_indexnumber extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         if($state == DOKU_LEXER_ENTER && preg_match('/<idxnum ([^#]+)(?:#(\d+)(.*))?>/', $match, $matches)) {
             $idxId = trim($matches[1]);
             if(empty($this->idxnumbers[$idxId])) {
@@ -117,7 +117,7 @@ class syntax_plugin_indexnumber extends DokuWiki_Syntax_Plugin {
      * 3 - Counter reference id, without # 
      * 4 - Description text
      */
-    function render($format, &$R, $data) {
+    function render($format, Doku_Renderer $R, $data) {
         if($format != 'xhtml'){
             return false;
         }


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.